### PR TITLE
Fixing Kubernets repository

### DIFF
--- a/roles/ops/tasks/helm.yaml
+++ b/roles/ops/tasks/helm.yaml
@@ -10,7 +10,7 @@
   apt_repository:
     repo: deb https://baltocdn.com/helm/stable/debian/ all main
     state: present
-    filename: helm-stable-debian.list
+    filename: helm-stable-debian
 
 - name: Install helm
   become: true

--- a/roles/ops/tasks/kubernetes.yaml
+++ b/roles/ops/tasks/kubernetes.yaml
@@ -15,6 +15,11 @@
 #   ansible.builtin.debug:
 #     msg: "{{ latest_kubernetes_version }}"
 
+- name: Check if /etc/apt/trusted.gpg.d/kubernetes-apt-keyring.asc exists
+  stat:
+    path: /etc/apt/trusted.gpg.d/kubernetes-apt-keyring.asc
+  register: kubernetes_apt_keyring
+
 - name: Add an apt signing key for Kubernetes
   become: true
   ansible.builtin.get_url:
@@ -24,6 +29,7 @@
     force: true
   when:
     - "latest_kubernetes_version is defined"
+    - "not kubernetes_apt_keyring.stat.exists"
 
 - name: Add apt repository for Kubernetes
   become: true
@@ -33,6 +39,7 @@
     filename: kubernetes
   when:
     - "latest_kubernetes_version is defined"
+    - "not kubernetes_apt_keyring.stat.exists"
 
 - name: Install kubeadm and kubectl
   become: true
@@ -67,38 +74,3 @@
   when: zshrc_file.stat.exists
 #  state: present
 #  create: yes
-
-# - name: Check for krew
-#   stat: path=/$HOME/.krew
-#   register: krew
-#
-# - name: Install krew
-#   shell: |
-#     set -x; cd "$(mktemp -d)" &&
-#     OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-#     ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-#     curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz" &&
-#     tar zxvf krew.tar.gz &&
-#     KREW=./krew-"${OS}_${ARCH}" &&
-#     "$KREW" install krew
-#   when: not krew.stat.exists
-#
-# - name: Get installed krew plugins
-#   command: "kubectl krew list"
-#   register: "krew_plugins"
-#
-# - name: Install krew plugins
-#   command: "kubectl krew install {{ item }}"
-#   when: "item|string not in krew_plugins.stdout_lines"
-#   with_items:
-#     - cert-manager
-#     - ctx
-#     - exec-cronjob
-#     - get-all
-#     - krew
-#     - ns
-#     - pod-dive
-#     - roll
-#     - snap
-#     - tail
-#     - view-utilization

--- a/roles/ops/tasks/kubernetes.yaml
+++ b/roles/ops/tasks/kubernetes.yaml
@@ -1,17 +1,38 @@
-# Taken from https://kubernetes.io/blog/2019/03/15/kubernetes-setup-using-ansible-and-vagrant/
 ---
+- name: Get the latest Kubernetes release information
+  uri:
+    url: "https://dl.k8s.io/release/stable.txt"
+    method: GET
+    return_content: true
+  register: latest_release_info
+
+- name: Display latest Kubernetes version
+  set_fact:
+    latest_kubernetes_version: "v{{ latest_release_info.content | regex_replace('v(\\d+\\.\\d+)\\..*', '\\1') }}"
+  when: latest_release_info.status == 200
+
+# - name: Display latest Kubernetes version
+#   ansible.builtin.debug:
+#     msg: "{{ latest_kubernetes_version }}"
+
 - name: Add an apt signing key for Kubernetes
   become: true
-  apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-    state: present
+  ansible.builtin.get_url:
+    url: "https://pkgs.k8s.io/core:/stable:/{{ latest_kubernetes_version }}/deb/Release.key"
+    dest: /etc/apt/trusted.gpg.d/kubernetes-apt-keyring.asc
+    mode: '0644'
+    force: true
+  when:
+    - "latest_kubernetes_version is defined"
 
 - name: Add apt repository for Kubernetes
   become: true
   apt_repository:
-    repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/{{ latest_kubernetes_version }}/deb/ /"
     state: present
-    filename: kubernetes.list
+    filename: kubernetes
+  when:
+    - "latest_kubernetes_version is defined"
 
 - name: Install kubeadm and kubectl
   become: true
@@ -19,6 +40,8 @@
     name: "{{ packages }}"
     state: present
     update_cache: true
+  when:
+    - "latest_kubernetes_version is defined"
   vars:
     packages:
       - kubelet

--- a/roles/ops/tasks/minikube.yaml
+++ b/roles/ops/tasks/minikube.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Install package dependencies.
+  become: true
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - xz-utils
+
 - name: Check if /usr/bin/minikube exists
   stat:
     path: /usr/bin/minikube

--- a/vars/prerequisite_packages.yaml
+++ b/vars/prerequisite_packages.yaml
@@ -8,3 +8,4 @@ prerequisite_packages:
   - jq
   - yamllint
   - tree
+  - xz-utils


### PR DESCRIPTION
The used Kubernetes repository is deprecated. The migration path [here](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate) was used to resolve the issue.